### PR TITLE
Ensure post-type links remain intact

### DIFF
--- a/src/http/get-catchall/views/includes/published.njk
+++ b/src/http/get-catchall/views/includes/published.njk
@@ -15,7 +15,7 @@
   {%- if format and format == 'full' %}
     <h3 class="text-sm md:text-base text-gray-500 uppercase mt-1">In</h3>
     <p>
-      <a href="/{{ helpers.pluralise(post['post-type'][0]) }}" class="capitalize text-yellow-600 hover:text-gray-800 dark:hover:text-gray-200">
+      <a href="/{{ helpers.pluralise(post['post-type'][0]) | lowercase }}" class="capitalize text-yellow-600 hover:text-gray-800 dark:hover:text-gray-200">
         {{ helpers.pluralise(post['post-type'][0]) }}
       </a>
     </p>


### PR DESCRIPTION
Currently, `pluralise` will return `/RSVPs`, which 404s, as the page is
actually `/rsvps`. To avoid this, we can make sure these are lowercase'd
to work correctly.
