### PR TITLE
Remove node-fetch dependency and use native fetch API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,9 @@
         "@architect/functions": "^8.1.9",
         "markdown-it": "^14.1.0",
         "markdown-it-handle": "^0.1.0",
-        "node-fetch": "^2.6.5",
         "nunjucks": "^3.2.3",
         "rss": "^1.2.2",
-        "sanitize-html": "^2.17.0",
-        "set-value": "^4.1.0"
+        "sanitize-html": "^2.17.0"
       },
       "devDependencies": {
         "@architect/architect": "^12.0.0",
@@ -5924,15 +5922,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-primitive": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
-      "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -6112,15 +6101,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/isomorphic-fetch": {
       "version": "3.0.0",
@@ -6756,6 +6736,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -8168,36 +8149,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/set-value": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
-      "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
-      "funding": [
-        "https://github.com/sponsors/jonschlinkert",
-        "https://paypal.me/jonathanschlinkert",
-        "https://jonschlinkert.dev/sponsor"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4",
-        "is-primitive": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=11.0"
-      }
-    },
-    "node_modules/set-value/node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -8765,6 +8716,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tree-kill": {
@@ -9133,6 +9085,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-fetch": {
@@ -9146,6 +9099,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,9 @@
     "@architect/functions": "^8.1.9",
     "markdown-it": "^14.1.0",
     "markdown-it-handle": "^0.1.0",
-    "node-fetch": "^2.6.5",
     "nunjucks": "^3.2.3",
     "rss": "^1.2.2",
-    "sanitize-html": "^2.17.0",
-    "set-value": "^4.1.0"
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@architect/architect": "^12.0.0",

--- a/src/http/get-barryfrost_jpg/index.js
+++ b/src/http/get-barryfrost_jpg/index.js
@@ -1,13 +1,12 @@
 // image proxy for legacy /barryfrost.jpg image
 
-const fetch = require('node-fetch')
 const arc = require('@architect/functions')
 
 async function fetchImage () {
   const url = new URL(arc.static('/barryfrost.jpg'), process.env.ROOT_URL).href
   const response = await fetch(url)
-  const buffer = await response.buffer()
-  const image = Buffer.from(buffer).toString('base64')
+  const arrayBuffer = await response.arrayBuffer()
+  const image = Buffer.from(arrayBuffer).toString('base64')
   return image
 }
 

--- a/src/http/get-catchall/api.js
+++ b/src/http/get-catchall/api.js
@@ -1,5 +1,3 @@
-const fetch = require('node-fetch')
-
 const micropubSourceUrl = `${process.env.MICROPUB_URL}?q=source`
 
 async function getPostType (postType, before) {

--- a/src/http/get-feed_json/index.js
+++ b/src/http/get-feed_json/index.js
@@ -1,4 +1,3 @@
-const fetch = require('node-fetch')
 const md = require('markdown-it')({
   linkify: true,
   html: true

--- a/src/http/get-map-catchall/index.js
+++ b/src/http/get-map-catchall/index.js
@@ -1,5 +1,3 @@
-const fetch = require('node-fetch')
-
 async function fetchImage (lat = 0, lng = 0, zoom = 15) {
   const token = process.env.MAPBOX_ACCESS_TOKEN
   const url = 'https://api.mapbox.com/styles/v1/mapbox/outdoors-v11/static/' +
@@ -10,8 +8,8 @@ async function fetchImage (lat = 0, lng = 0, zoom = 15) {
     const text = await response.text()
     console.error('Error from Mapbox', text)
   } else {
-    const buffer = await response.buffer()
-    const image = Buffer.from(buffer).toString('base64')
+    const arrayBuffer = await response.arrayBuffer()
+    const image = Buffer.from(arrayBuffer).toString('base64')
     return image
   }
 }

--- a/src/http/get-rss/index.js
+++ b/src/http/get-rss/index.js
@@ -1,5 +1,4 @@
 const RSS = require('rss')
-const fetch = require('node-fetch')
 const md = require('markdown-it')({
   linkify: true,
   html: true

--- a/src/http/post-notify/index.js
+++ b/src/http/post-notify/index.js
@@ -1,5 +1,4 @@
 const arc = require('@architect/functions')
-const fetch = require('node-fetch')
 
 exports.handler = async function http (req) {
   const body = arc.http.helpers.bodyParser(req)


### PR DESCRIPTION
## Summary
This PR removes the `node-fetch` dependency and replaces all usages with the native `fetch` API available in modern Node.js versions. Additionally, the unused `set-value` dependency has been removed.

## Key Changes
- Removed `node-fetch` from dependencies (moved to devDependencies only where needed)
- Removed unused `set-value` package and its transitive dependencies (`is-primitive`, `isobject`, `is-plain-object`)
- Updated all `require('node-fetch')` statements across the codebase to use the global `fetch` API
- Replaced `response.buffer()` calls with `response.arrayBuffer()` to match the native Fetch API specification
- Updated files:
  - `src/http/get-barryfrost_jpg/index.js`
  - `src/http/get-catchall/api.js`
  - `src/http/get-feed_json/index.js`
  - `src/http/get-map-catchall/index.js`
  - `src/http/get-rss/index.js`
  - `src/http/post-notify/index.js`

## Implementation Details
- The native `fetch` API is available globally in Node.js 18+ without requiring external packages
- `response.arrayBuffer()` is the standard method in the Fetch API (replacing the node-fetch-specific `response.buffer()`)
- `Buffer.from()` correctly handles both `ArrayBuffer` and `Buffer` inputs, so the conversion logic remains unchanged
- This reduces the dependency footprint and improves maintainability by relying on standard APIs

https://claude.ai/code/session_01FMsqetKRSu8axiq7X37RaF